### PR TITLE
Support for Elvis operator: obj?.prop and fn()

### DIFF
--- a/test/tests-6to5-playground.js
+++ b/test/tests-6to5-playground.js
@@ -609,3 +609,65 @@ test("arr.map(#toFixed(2))", {
 }, {
   playground: true
 });
+
+test("obj?.prop", {
+  type: "Program",
+  start: 0,
+  end: 9,
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 9,
+      expression: {
+        type: "MemberExpression",
+        start: 0,
+        end: 9,
+        object: {
+          type: "Identifier",
+          start: 0,
+          end: 3,
+          name: "obj",
+          optional: true
+        },
+        property: {
+          type: "Identifier",
+          start: 5,
+          end: 9,
+          name: "prop"
+        },
+        computed: false
+      }
+    }
+  ]
+}, {
+  playground: true
+});
+
+test("foo?()", {
+  type: "Program",
+  start: 0,
+  end: 6,
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 6,
+      expression: {
+        type: "CallExpression",
+        start: 0,
+        end: 6,
+        callee: {
+          type: "Identifier",
+          start: 0,
+          end: 3,
+          name: "foo",
+          optional: true
+        },
+        arguments: []
+      }
+    }
+  ]
+}, {
+  playground: true
+});


### PR DESCRIPTION
Refs babel/babel#9

Add support for "Elvis" operator. If `Identifier` + `?` is found and followed (immediately) by a `.` or a `(`, then the identifier is marked as "optional" (via a new `optional` property).

Not sure if we should allow whitespaces between `?` and `.` or `(`. Currently:

```js
obj?.prop // OK
obj ?. prop // OK
obj ? . prop // not ok
```